### PR TITLE
Hybrid NPM Module for ESM and CommonJS

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,8 +7,8 @@
   "types": "dist/index.d.ts",
   "exports": {
     ".": {
-        "import": "./dist/mjs/index.js",
-        "require": "./dist/cjs/index.js"
+      "import": "./dist/mjs/index.js",
+      "require": "./dist/cjs/index.js"
     }
   },
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,14 +1,20 @@
 {
-  "type": "module",
   "name": "ollama",
   "version": "0.4.0",
   "description": "Ollama Javascript library",
-  "main": "dist/index.js",
+  "main": "dist/cjs/index.js",
+  "module": "dist/mjs/index.js",
   "types": "dist/index.d.ts",
+  "exports": {
+    ".": {
+        "import": "./dist/mjs/index.js",
+        "require": "./dist/cjs/index.js"
+    }
+  },
   "scripts": {
     "format": "prettier --write .",
     "test": "jest --config=jest.config.cjs ./test/*",
-    "build": "mkdir -p dist && touch dist/cleanup && rm dist/* && tsc -b",
+    "build": "rm -fr dist/* && tsc -p tsconfig.json && tsc -p tsconfig-cjs.json && node scripts/build-cjs-mjs.js",
     "lint": "eslint ./src/* ./test/*",
     "prepublishOnly": "npm run build"
   },

--- a/scripts/build-cjs-mjs.js
+++ b/scripts/build-cjs-mjs.js
@@ -1,0 +1,15 @@
+const fs = require('fs');
+const path = require('path');
+
+// Function to create a package.json file with specified type
+function createPackageJson(dir, type) {
+    const content = {
+        type: type
+    };
+    const filePath = path.join(dir, 'package.json');
+    fs.mkdirSync(dir, { recursive: true });
+    fs.writeFileSync(filePath, JSON.stringify(content, null, 4));
+}
+
+createPackageJson('dist/cjs', 'commonjs');
+createPackageJson('dist/mjs', 'module');

--- a/scripts/build-cjs-mjs.js
+++ b/scripts/build-cjs-mjs.js
@@ -1,15 +1,15 @@
-const fs = require('fs');
-const path = require('path');
+const fs = require('fs')
+const path = require('path')
 
 // Function to create a package.json file with specified type
 function createPackageJson(dir, type) {
-    const content = {
-        type: type
-    };
-    const filePath = path.join(dir, 'package.json');
-    fs.mkdirSync(dir, { recursive: true });
-    fs.writeFileSync(filePath, JSON.stringify(content, null, 4));
+  const content = {
+    type: type,
+  }
+  const filePath = path.join(dir, 'package.json')
+  fs.mkdirSync(dir, { recursive: true })
+  fs.writeFileSync(filePath, JSON.stringify(content, null, 4))
 }
 
-createPackageJson('dist/cjs', 'commonjs');
-createPackageJson('dist/mjs', 'module');
+createPackageJson('dist/cjs', 'commonjs')
+createPackageJson('dist/mjs', 'module')

--- a/tsconfig-base.json
+++ b/tsconfig-base.json
@@ -1,0 +1,20 @@
+{
+	"compilerOptions": {
+		"noImplicitAny": false,
+		"noImplicitThis": true,
+		"strictNullChecks": true,
+		"esModuleInterop": true,
+		"declaration": true,
+		"declarationMap": true,
+		"skipLibCheck": true,
+		"strict": true,
+		"forceConsistentCasingInFileNames": true,
+		"moduleResolution": "node",
+	},
+	"include": [
+		"./src/**/*.ts"
+	],
+	"exclude": [
+		"node_modules"
+	]
+}

--- a/tsconfig-base.json
+++ b/tsconfig-base.json
@@ -1,20 +1,16 @@
 {
-	"compilerOptions": {
-		"noImplicitAny": false,
-		"noImplicitThis": true,
-		"strictNullChecks": true,
-		"esModuleInterop": true,
-		"declaration": true,
-		"declarationMap": true,
-		"skipLibCheck": true,
-		"strict": true,
-		"forceConsistentCasingInFileNames": true,
-		"moduleResolution": "node",
-	},
-	"include": [
-		"./src/**/*.ts"
-	],
-	"exclude": [
-		"node_modules"
-	]
+  "compilerOptions": {
+    "noImplicitAny": false,
+    "noImplicitThis": true,
+    "strictNullChecks": true,
+    "esModuleInterop": true,
+    "declaration": true,
+    "declarationMap": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "moduleResolution": "node"
+  },
+  "include": ["./src/**/*.ts"],
+  "exclude": ["node_modules"]
 }

--- a/tsconfig-cjs.json
+++ b/tsconfig-cjs.json
@@ -1,0 +1,8 @@
+{
+    "extends": "./tsconfig-base.json",
+    "compilerOptions": {
+        "module": "commonjs",
+        "outDir": "dist/cjs",
+        "target": "es2015"
+    }
+}

--- a/tsconfig-cjs.json
+++ b/tsconfig-cjs.json
@@ -1,8 +1,8 @@
 {
-    "extends": "./tsconfig-base.json",
-    "compilerOptions": {
-        "module": "commonjs",
-        "outDir": "dist/cjs",
-        "target": "es2015"
-    }
+  "extends": "./tsconfig-base.json",
+  "compilerOptions": {
+    "module": "commonjs",
+    "outDir": "dist/cjs",
+    "target": "es2015"
+  }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,8 +1,8 @@
 {
-    "extends": "./tsconfig-base.json",
-    "compilerOptions": {
-        "module": "esnext",
-        "outDir": "dist/mjs",
-        "target": "esnext"
-    }
+  "extends": "./tsconfig-base.json",
+  "compilerOptions": {
+    "module": "esnext",
+    "outDir": "dist/mjs",
+    "target": "esnext",
+  },
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,26 +1,8 @@
 {
-  "compilerOptions": {
-    "noImplicitAny": false,
-    "noImplicitThis": true,
-    "strictNullChecks": true,
-    "esModuleInterop": true,
-    "declaration": true,
-    "declarationMap": true,
-    "skipLibCheck": true,
-    "strict": true,
-    "forceConsistentCasingInFileNames": true,
-    "moduleResolution": "node",
-    "module": "ES2022",
-    "outDir": "./dist",
-    "target": "ES6",
-  },
-
-  "ts-node": {
-    "swc": true,
-    "esm": true,
-  },
-
-  "include": ["./src/**/*.ts"],
-
-  "exclude": ["node_modules"],
+    "extends": "./tsconfig-base.json",
+    "compilerOptions": {
+        "module": "esnext",
+        "outDir": "dist/mjs",
+        "target": "esnext"
+    }
 }


### PR DESCRIPTION
Update the library to allow the NPM module to be used in both ESM and CommonJS.

This javascript library previously targeted ES modules. This means modern ES projects could use the library but requiring the library in CommonJS would error. This change to the build allows the same library to be used in both ES modules and CommonJS.

ESM:
```
import { Ollama } from "ollama";
```

CJS:
```
const { Ollama } = require("ollama");
```

