### PR TITLE
ollama.embeddings needs spread operator on request (see issue #29)

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -305,7 +305,7 @@ export class Ollama {
 
   async embeddings(request: EmbeddingsRequest): Promise<EmbeddingsResponse> {
     const response = await utils.post(this.fetch, `${this.config.host}/api/embeddings`, {
-      request,
+      ...request,
     })
     const embeddingsResponse = (await response.json()) as EmbeddingsResponse
     return embeddingsResponse


### PR DESCRIPTION
The third argument to `utils.post` should be the raw request body, but the `embeddings` method currently misses the spread operator used by all the other ollama wrappers. As a result, embeddings calls generate a JSON request body that looks like this:

```
{
  request: {
    model: 'llama2',
    prompt: 'Some text here...'
  }
}
```

instead of this:
```
{
  model: 'llama2',
  prompt: 'Some text here...'
}
```

This commit adds the spread operator, fixing the embeddings method.