### PR TITLE
Add optional proxy flag to config

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -33,7 +33,10 @@ export class Ollama {
 
   constructor(config?: Partial<Config>) {
     this.config = {
-      host: utils.formatHost(config?.host ?? 'http://127.0.0.1:11434'),
+      host: '',
+    }
+    if (!config?.proxy) {
+      this.config.host = utils.formatHost(config?.host ?? 'http://127.0.0.1:11434')
     }
 
     this.fetch = fetch

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -3,6 +3,7 @@ export type Fetch = typeof fetch
 export interface Config {
   host: string
   fetch?: Fetch
+  proxy?: boolean
 }
 
 // request types


### PR DESCRIPTION
Enforcing a default host is too restrictive when running Ollama through a proxy.

Added optional `proxy` flag to the config object to solve this.