### PR TITLE
add an abort controller

### DIFF
--- a/examples/abort/abort.ts
+++ b/examples/abort/abort.ts
@@ -1,0 +1,24 @@
+import ollama from 'ollama'
+
+// Set a timeout to abort the request after 1 second
+setTimeout(() => {
+  console.log('\nAborting request...\n')
+  ollama.abort()
+}, 1000) // 1000 milliseconds = 1 second
+
+try {
+  const stream = await ollama.generate({
+    model: 'llama2',
+    prompt: 'Write a long story',
+    stream: true,
+  })
+  for await (const chunk of stream) {
+    process.stdout.write(chunk.response)
+  }
+} catch (error) {
+  if (error.name === 'AbortError') {
+    console.log('The request has been aborted')
+  } else {
+    console.error('An error occurred:', error)
+  }
+}

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -62,6 +62,7 @@ export const post = async (
   fetch: Fetch,
   host: string,
   data?: Record<string, unknown> | BodyInit,
+  options?: { signal: AbortSignal },
 ): Promise<Response> => {
   const isRecord = (input: any): input is Record<string, unknown> => {
     return input !== null && typeof input === 'object' && !Array.isArray(input)
@@ -72,6 +73,7 @@ export const post = async (
   const response = await fetch(host, {
     method: 'POST',
     body: formattedData,
+    signal: options?.signal,
   })
 
   await checkOk(response)


### PR DESCRIPTION
Allow streamable requests to be aborted, and not block Ollama.

Resolves #39 