### PR TITLE
fix: add missing interface options

### DIFF
--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -41,8 +41,6 @@ export interface Options {
   mirostat_eta: number
   penalize_newline: boolean
   stop: string[]
-  rope_frequency_base: number
-  rope_frequency_scale: number
 }
 
 export interface GenerateRequest {

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -13,7 +13,6 @@ export interface Options {
   num_ctx: number
   num_batch: number
   num_gpu: number
-  num_gqa: number
   main_gpu: number
   low_vram: boolean
   f16_kv: boolean

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -12,6 +12,8 @@ export interface Options {
   numa: boolean
   num_ctx: number
   num_batch: number
+  num_gpu: number
+  num_gqa: number
   main_gpu: number
   low_vram: boolean
   f16_kv: boolean
@@ -40,6 +42,8 @@ export interface Options {
   mirostat_eta: number
   penalize_newline: boolean
   stop: string[]
+  rope_frequency_base: number
+  rope_frequency_scale: number
 }
 
 export interface GenerateRequest {


### PR DESCRIPTION
This PR adds the following missing options to the `Options` interface.

- num_gpu
- num_gqa
- rope_frequency_base
- rope_frequency_scale

See https://github.com/ollama/ollama/blob/main/docs/api.md#request-6