### PR TITLE
mark `embeddings()` method as deprecated in favor of `embed()`

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,18 +174,19 @@ ollama.show(request)
   - `options` `<Options>`: (Optional) Options to configure the runtime.
 - Returns: `<ShowResponse>`
 
-### embeddings
+### embed
 
 ```javascript
-ollama.embeddings(request)
+ollama.embed(request)
 ```
 
 - `request` `<Object>`: The request object containing embedding parameters.
   - `model` `<string>` The name of the model used to generate the embeddings.
-  - `prompt` `<string>`: The prompt used to generate the embedding.
+  - `input` `<string>`: The input used to generate the embedding.
+  - `truncate` `<boolean>`: (Optional) Truncate the input to fit the maximum context length supported by the model.
   - `keep_alive` `<string | number>`: (Optional) How long to keep the model loaded.
   - `options` `<Options>`: (Optional) Options to configure the runtime.
-- Returns: `<EmbeddingsResponse>`
+- Returns: `<EmbedResponse>`
 
 ### ps
 

--- a/README.md
+++ b/README.md
@@ -182,7 +182,7 @@ ollama.embed(request)
 
 - `request` `<Object>`: The request object containing embedding parameters.
   - `model` `<string>` The name of the model used to generate the embeddings.
-  - `input` `<string>`: The input used to generate the embedding.
+  - `input` `<string> | <string[]>`: The input used to generate the embedding.
   - `truncate` `<boolean>`: (Optional) Truncate the input to fit the maximum context length supported by the model.
   - `keep_alive` `<string | number>`: (Optional) How long to keep the model loaded.
   - `options` `<Options>`: (Optional) Options to configure the runtime.

--- a/src/browser.ts
+++ b/src/browser.ts
@@ -286,6 +286,7 @@ async encodeImage(image: Uint8Array | string): Promise<string> {
 
   /**
    * Embeds a text prompt into a vector.
+   * @deprecated Use the `embed` method instead.
    * @param request {EmbeddingsRequest} - The request object.
    * @returns {Promise<EmbeddingsResponse>} - The response object.
    */

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -119,6 +119,9 @@ export interface EmbedRequest {
   options?: Partial<Options>
 }
 
+/**
+ * @deprecated Use the EmbedRequest interface with the embed() method instead.
+ */
 export interface EmbeddingsRequest {
   model: string
   prompt: string
@@ -163,6 +166,9 @@ export interface EmbedResponse {
   embeddings: number[][]
 }
 
+/**
+ * @deprecated Use the embed() method with the EmbedResponse instead.
+ */
 export interface EmbeddingsResponse {
   embedding: number[]
 }


### PR DESCRIPTION
- mark the `embeddings()` method as deprecated, `embed()` is a drop-in replacement that also allows for batch embeddings
- the embeddings method will continue to work as expected
- document the embed method

This PR relies on the next release of Ollama.