### PR TITLE
Add `examples` to `.npmignore`

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -12,3 +12,4 @@ yarn.lock
 jest.config.cjs
 tsconfig.json
 test
+examples


### PR DESCRIPTION
There is no need to include the `examples` directory when installing the `ollama` client since it won't be used, and the package size will be reduced by ~90KB.