### PR TITLE
Fix host breaking when set to only port

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -266,7 +266,7 @@ export const formatHost = (host: string): string => {
   if (host.startsWith(':')) {
     // if host starts with ':', prepend the default hostname
     host = `http://127.0.0.1${host}`
-    isExplicitProtocol = false
+    isExplicitProtocol = true
   }
 
   if (!isExplicitProtocol) {

--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -13,6 +13,10 @@ describe('formatHost Function Tests', () => {
     expect(formatHost('1.2.3.4:56789')).toBe('http://1.2.3.4:56789')
   })
 
+  it('should parse with only a port', () => {
+    expect(formatHost(':56789')).toBe('http://127.0.0.1:56789')
+  })
+
   it('should parse HTTP URL', () => {
     expect(formatHost('http://1.2.3.4')).toBe('http://1.2.3.4:80')
   })
@@ -51,5 +55,9 @@ describe('formatHost Function Tests', () => {
 
   it('should handle trailing slash in domain with port', () => {
     expect(formatHost('example.com:56789/')).toBe('http://example.com:56789')
+  })
+
+  it('should handle traling slash with only a port', () => {
+    expect(formatHost(':56789/')).toBe('http://127.0.0.1:56789')
   })
 })


### PR DESCRIPTION
I noticed that setting the host to only a port - see example below, would break the formatting and return a jumbled host `http://http:11434//127.0.0.1:11434`. I confirmed this is an issue on both Node and Deno, see attached images.

```js
const ollama = new Ollama({ host: ":11434" });
```

<img width="1260" alt="Screenshot 2024-07-19 at 22 44 42" src="https://github.com/user-attachments/assets/0fb958fe-0203-4575-94c8-384a92943ce8">

<img width="1263" alt="Screenshot 2024-07-19 at 22 45 12" src="https://github.com/user-attachments/assets/1fa8cc87-3ba5-42d6-92ea-e5847c43e455">

Wrote a quick test for the formatted and tested 19 different variants - see attached image, which confirmed the issue was only present when passing in a port to `formatHost`.

<img width="935" alt="Screenshot 2024-07-19 at 22 47 41" src="https://github.com/user-attachments/assets/4bb5514e-5e95-49cb-9d96-720247406858">

Setting `isExplicitProtocol` to `true` instead of `false` fixes this issue.

<img width="1031" alt="Screenshot 2024-07-19 at 22 50 22" src="https://github.com/user-attachments/assets/5b270a70-73c1-452c-85c7-f0bfb83765d3">
