### PR TITLE
Add `.github` and `.prettierrc.json` to `.npmignore`

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -9,7 +9,9 @@ yarn.lock
 .gitignore
 .eslintrc.cjs
 .eslintignore
+.prettierrc.json
 jest.config.cjs
 tsconfig.json
 test
 examples
+.github


### PR DESCRIPTION
`.github` and `.prettierrc.json` can be ignored when installing via npm, these are not needed for the package to work for the end user.