### PR TITLE
enable ollama-js use in an environment without whatwg

### DIFF
--- a/src/browser.ts
+++ b/src/browser.ts
@@ -1,6 +1,5 @@
 import * as utils from './utils.js'
 import { AbortableAsyncIterator, parseJSON, post } from './utils.js'
-import 'whatwg-fetch'
 
 import type {
   ChatRequest,
@@ -39,9 +38,24 @@ export class Ollama {
       this.config.host = utils.formatHost(config?.host ?? 'http://127.0.0.1:11434')
     }
 
-    this.fetch = fetch
-    if (config?.fetch != null) {
-      this.fetch = config.fetch
+    this.fetch = config?.fetch || this.getFetch();
+  }
+
+  private getFetch(): Fetch {
+    if (typeof window !== 'undefined' && window.fetch) {
+      return window.fetch.bind(window);
+    }
+    
+    if (typeof global !== 'undefined' && global.fetch) {
+      return global.fetch;
+    }
+    
+    try {
+      // Use dynamic import for Node.js environments
+      return require('node-fetch');
+    } catch (error) {
+      console.error('Failed to import node-fetch:', error);
+      throw new Error('Fetch is not available. Please provide a fetch implementation in the config.');
     }
   }
 


### PR DESCRIPTION
- use dynamic import to allow setting fetch without whatwg-fetch being present

When trying to vendor `ollama-js` into a basic JavaScript project I hit an issue that this import of `whatwg-fetch` not being simple to resolve. This change allows for setting the fetch library used by Ollama in an environment where `whatwg-fetch` is not present.

Example:
```
async function initOllama() {
  try {
    const ollamaModule = await import('/public/vendor/ollama/dist/browser.mjs');
    // Create an instance of Ollama with a custom fetch implementation
    const ollama = new ollamaModule.Ollama({
      fetch: window.fetch
    });
    return ollama;
  } catch (error) {
    console.error('Error initializing Ollama:', error);
    throw error;
  }
}
```