### PR TITLE
chore: support typescript checking in tests

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -25,7 +25,7 @@
     "esm": true,
   },
 
-  "include": ["./src/**/*.ts"],
+  "include": ["./src/**/*.ts", "./test/**/*.ts"],
 
   "exclude": ["node_modules"],
 }


### PR DESCRIPTION
Likely depends on: https://github.com/ollama/ollama-js/pull/173
Updating `tsconfig` to get proper type-checking in tests.