### PR TITLE
refactor: message role to union type

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ ollama.chat(request)
 
   - `model` `<string>` The name of the model to use for the chat.
   - `messages` `<Message[]>`: Array of message objects representing the chat history.
-    - `role` `<string>`: The role of the message sender ('user', 'system', or 'assistant').
+    - `role` `<string>`: The role of the message sender ('user', 'system', 'assistant' or 'tool').
     - `content` `<string>`: The content of the message.
     - `images` `<Uint8Array[] | string[]>`: (Optional) Images to be included in the message, either as Uint8Array or base64 encoded strings.
   - `format` `<string>`: (Optional) Set the expected format of the response (`json`).

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -61,7 +61,7 @@ export interface GenerateRequest {
 }
 
 export interface Message {
-  role: string
+  role: 'system' | 'user' | 'assistant' | 'tool'
   content: string
   images?: Uint8Array[] | string[]
   tool_calls?: ToolCall[]


### PR DESCRIPTION
According to the [Ollama chat completion API](https://github.com/ollama/ollama/blob/main/docs/api.md#generate-a-chat-completion), the role parameter in message should be one of the following: system, user, assistant, or tool.

Therefore, I have updated the role type from a generic string to a union type. Additionally, I have aligned the README to include the 'tool' role.