### PR TITLE
docs: specify the format for keep_alive duration

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ ollama.chat(request)
     - `images` `<Uint8Array[] | string[]>`: (Optional) Images to be included in the message, either as Uint8Array or base64 encoded strings.
   - `format` `<string>`: (Optional) Set the expected format of the response (`json`).
   - `stream` `<boolean>`: (Optional) When true an `AsyncGenerator` is returned.
-  - `keep_alive` `<string | number>`: (Optional) How long to keep the model loaded.
+  - `keep_alive` `<string | number>`: (Optional) How long to keep the model loaded. A number (seconds) or a string with a duration unit suffix: "300ms", "1.5h", "2h45m", etc.
   - `tools` `<Tool[]>`: (Optional) A list of tool calls the model may make.
   - `options` `<Options>`: (Optional) Options to configure the runtime.
 
@@ -93,7 +93,7 @@ ollama.generate(request)
   - `images` `<Uint8Array[] | string[]>`: (Optional) Images to be included, either as Uint8Array or base64 encoded strings.
   - `format` `<string>`: (Optional) Set the expected format of the response (`json`).
   - `stream` `<boolean>`: (Optional) When true an `AsyncGenerator` is returned.
-  - `keep_alive` `<string | number>`: (Optional) How long to keep the model loaded.
+  - `keep_alive` `<string | number>`: (Optional) How long to keep the model loaded. A number (seconds) or a string with a duration unit suffix: "300ms", "1.5h", "2h45m", etc.
   - `options` `<Options>`: (Optional) Options to configure the runtime.
 - Returns: `<GenerateResponse>`
 
@@ -186,7 +186,7 @@ ollama.embed(request)
   - `model` `<string>` The name of the model used to generate the embeddings.
   - `input` `<string> | <string[]>`: The input used to generate the embeddings.
   - `truncate` `<boolean>`: (Optional) Truncate the input to fit the maximum context length supported by the model.
-  - `keep_alive` `<string | number>`: (Optional) How long to keep the model loaded.
+  - `keep_alive` `<string | number>`: (Optional) How long to keep the model loaded. A number (seconds) or a string with a duration unit suffix: "300ms", "1.5h", "2h45m", etc.
   - `options` `<Options>`: (Optional) Options to configure the runtime.
 - Returns: `<EmbedResponse>`
 

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ ollama.chat(request)
     - `images` `<Uint8Array[] | string[]>`: (Optional) Images to be included in the message, either as Uint8Array or base64 encoded strings.
   - `format` `<string>`: (Optional) Set the expected format of the response (`json`).
   - `stream` `<boolean>`: (Optional) When true an `AsyncGenerator` is returned.
-  - `keep_alive` `<string | number>`: (Optional) How long to keep the model loaded. A number (seconds) or a string with a duration unit suffix: "300ms", "1.5h", "2h45m", etc.
+  - `keep_alive` `<string | number>`: (Optional) How long to keep the model loaded. A number (seconds) or a string with a duration unit suffix ("300ms", "1.5h", "2h45m", etc.)
   - `tools` `<Tool[]>`: (Optional) A list of tool calls the model may make.
   - `options` `<Options>`: (Optional) Options to configure the runtime.
 
@@ -93,7 +93,7 @@ ollama.generate(request)
   - `images` `<Uint8Array[] | string[]>`: (Optional) Images to be included, either as Uint8Array or base64 encoded strings.
   - `format` `<string>`: (Optional) Set the expected format of the response (`json`).
   - `stream` `<boolean>`: (Optional) When true an `AsyncGenerator` is returned.
-  - `keep_alive` `<string | number>`: (Optional) How long to keep the model loaded. A number (seconds) or a string with a duration unit suffix: "300ms", "1.5h", "2h45m", etc.
+  - `keep_alive` `<string | number>`: (Optional) How long to keep the model loaded. A number (seconds) or a string with a duration unit suffix ("300ms", "1.5h", "2h45m", etc.)
   - `options` `<Options>`: (Optional) Options to configure the runtime.
 - Returns: `<GenerateResponse>`
 
@@ -186,7 +186,7 @@ ollama.embed(request)
   - `model` `<string>` The name of the model used to generate the embeddings.
   - `input` `<string> | <string[]>`: The input used to generate the embeddings.
   - `truncate` `<boolean>`: (Optional) Truncate the input to fit the maximum context length supported by the model.
-  - `keep_alive` `<string | number>`: (Optional) How long to keep the model loaded. A number (seconds) or a string with a duration unit suffix: "300ms", "1.5h", "2h45m", etc.
+  - `keep_alive` `<string | number>`: (Optional) How long to keep the model loaded. A number (seconds) or a string with a duration unit suffix ("300ms", "1.5h", "2h45m", etc.)
   - `options` `<Options>`: (Optional) Options to configure the runtime.
 - Returns: `<EmbedResponse>`
 

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -55,7 +55,7 @@ export interface GenerateRequest {
   raw?: boolean
   format?: string | object
   images?: Uint8Array[] | string[]
-  keep_alive?: string | number
+  keep_alive?: string | number // a number (seconds) or a string with a duration unit suffix: "300ms", "1.5h", "2h45m", etc
 
   options?: Partial<Options>
 }
@@ -100,7 +100,7 @@ export interface ChatRequest {
   messages?: Message[]
   stream?: boolean
   format?: string | object
-  keep_alive?: string | number
+  keep_alive?: string | number // a number (seconds) or a string with a duration unit suffix: "300ms", "1.5h", "2h45m", etc
   tools?: Tool[]
 
   options?: Partial<Options>
@@ -146,7 +146,7 @@ export interface EmbedRequest {
   model: string
   input: string | string[]
   truncate?: boolean
-  keep_alive?: string | number
+  keep_alive?: string | number // a number (seconds) or a string with a duration unit suffix: "300ms", "1.5h", "2h45m", etc
 
   options?: Partial<Options>
 }
@@ -154,7 +154,7 @@ export interface EmbedRequest {
 export interface EmbeddingsRequest {
   model: string
   prompt: string
-  keep_alive?: string | number
+  keep_alive?: string | number // a number (seconds) or a string with a duration unit suffix: "300ms", "1.5h", "2h45m", etc
 
   options?: Partial<Options>
 }

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -55,7 +55,7 @@ export interface GenerateRequest {
   raw?: boolean
   format?: string | object
   images?: Uint8Array[] | string[]
-  keep_alive?: string | number // a number (seconds) or a string with a duration unit suffix: "300ms", "1.5h", "2h45m", etc
+  keep_alive?: string | number // a number (seconds) or a string with a duration unit suffix ("300ms", "1.5h", "2h45m", etc)
 
   options?: Partial<Options>
 }
@@ -100,7 +100,7 @@ export interface ChatRequest {
   messages?: Message[]
   stream?: boolean
   format?: string | object
-  keep_alive?: string | number // a number (seconds) or a string with a duration unit suffix: "300ms", "1.5h", "2h45m", etc
+  keep_alive?: string | number // a number (seconds) or a string with a duration unit suffix ("300ms", "1.5h", "2h45m", etc)
   tools?: Tool[]
 
   options?: Partial<Options>
@@ -146,7 +146,7 @@ export interface EmbedRequest {
   model: string
   input: string | string[]
   truncate?: boolean
-  keep_alive?: string | number // a number (seconds) or a string with a duration unit suffix: "300ms", "1.5h", "2h45m", etc
+  keep_alive?: string | number // a number (seconds) or a string with a duration unit suffix ("300ms", "1.5h", "2h45m", etc)
 
   options?: Partial<Options>
 }
@@ -154,7 +154,7 @@ export interface EmbedRequest {
 export interface EmbeddingsRequest {
   model: string
   prompt: string
-  keep_alive?: string | number // a number (seconds) or a string with a duration unit suffix: "300ms", "1.5h", "2h45m", etc
+  keep_alive?: string | number // a number (seconds) or a string with a duration unit suffix ("300ms", "1.5h", "2h45m", etc)
 
   options?: Partial<Options>
 }


### PR DESCRIPTION
The Ollama API accepts a Go `time.Duration` as the `keep_alive` time parameter. Its not clearly documented anywhere how it expects the duration to be formatted, and the default behavior (numbers are seconds) is not expected. Adding documentation around this to make it easier to use `keep_alive`.

Resolves #81 