### PR TITLE
Export `AbortableAsyncIterator` class as type

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -173,3 +173,5 @@ export default new Ollama()
 
 // export all types from the main entry point so that packages importing types dont need to specify paths
 export * from './interfaces.js'
+
+export type { AbortableAsyncIterator }


### PR DESCRIPTION
Fixes #187 issue by just exporting `AbortableAsyncIterator` class as type from `src/index.ts` file.
