### PR TITLE
feat: add string model field to the ModelResponse interface

### DIFF
--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -209,6 +209,7 @@ export interface ProgressResponse {
 export interface ModelResponse {
   name: string
   modified_at: Date
+  model: string
   size: number
   digest: string
   details: ModelDetails


### PR DESCRIPTION
Minor thing, I noticed when listing the models via `ollama.list()` the `models` within the response value is of type `ModelResponse` and that the json returned has a field of `model` but the interface doesn't. You can see the output to doing `ollama.list` below.

Code:

```ts
import { Ollama } from './src/index'

const ollama = new Ollama()
const models = await ollama.list()

console.log(models)
```

Output:
```sh
ollama-js [ main][!][📦 v0.0.0][ v22.9.0]
❯ bun main.ts 
{
  models: [
    {
      name: "qwen2.5-coder:14b",
      model: "qwen2.5-coder:14b",
      modified_at: "2025-01-04T20:56:34.562706389Z",
      size: 8988124256,
      digest: "3028237cc8c52fea4e77185d72cc997b2e90392791f7c82fe1c71995d56e642d",
      details: [Object ...],
    }, {
      name: "opencoder:latest",
      model: "opencoder:latest",
      modified_at: "2025-01-04T20:12:03.407279743Z",
      size: 4736066175,
      digest: "cd882db52297841eb2721a191b598b7671cef506fc8ef123ff1ce04d6863d49f",
      details: [Object ...],
    }, {
      name: "llama3.2:latest",
      model: "llama3.2:latest",
      modified_at: "2025-01-04T20:10:29.319853066Z",
      size: 2019393189,
      digest: "a80c4f17acd55265feec403c7aef86be0c25983ab279d83f3bcd3abbcb5b8b72",
      details: [Object ...],
    }
  ],
}
```

I also checked the output of `ollama.ps()` as this also uses this interface, output also has `model` as a field on the object.
```sh
{
  models: [
    {
      name: "qwen2.5-coder:14b",
      model: "qwen2.5-coder:14b",
      size: 11550902272,
      digest: "3028237cc8c52fea4e77185d72cc997b2e90392791f7c82fe1c71995d56e642d",
      details: [Object ...],
      expires_at: "2025-01-04T23:30:42.305015625Z",
      size_vram: 11550902272,
    }
  ],
}
```