### PR TITLE
Fix: Use node: prefix for built-in modules

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,7 @@
 import { AbortableAsyncIterator } from './utils.js'
 
-import fs, { promises } from 'fs'
-import { resolve } from 'path'
+import fs, { promises } from 'node:fs'
+import { resolve } from 'node:path'
 import { Ollama as OllamaBrowser } from './browser.js'
 
 import type { CreateRequest, ProgressResponse } from './interfaces.js'


### PR DESCRIPTION
Fix: Use `node:` prefix for built-in modules

This pull request updates the import statements for the `fs` and `path` modules to use the `node:` prefix. This is the recommended modern way to import Node.js core modules and improves code clarity, prevents potential naming conflicts, and enhances future compatibility.  It also can sometimes help with tree-shaking in bundlers.

Specifically, the following changes were made:

* `import fs, { promises } from 'fs'` changed to `import fs, { promises } from 'node:fs'`
* `import { resolve } from 'path'` changed to `import { resolve } from 'node:path'`

This change ensures that the code explicitly imports the built-in Node.js modules and avoids any ambiguity.  It's a best practice for maintainable and robust Node.js code.
