### PR TITLE
fix: Normalize header handling for all HeaderInit types

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -101,6 +101,30 @@ function getPlatform(): string {
 }
 
 /**
+ * Normalizes headers into a plain object format.
+ * This function handles various types of HeaderInit objects such as Headers, arrays of key-value pairs,
+ * and plain objects, converting them all into an object structure.
+ *
+ * @param {HeadersInit|undefined} headers - The headers to normalize. Can be one of the following:
+ *   - A `Headers` object from the Fetch API.
+ *   - A plain object with key-value pairs representing headers.
+ *   - An array of key-value pairs representing headers.
+ * @returns {Record<string,string>} - A plain object representing the normalized headers.
+ */
+function normalizeHeaders(headers?: HeadersInit | undefined): Record<string,string> {
+  if (headers instanceof Headers) {
+      // If headers are an instance of Headers, convert it to an object
+      return Object.fromEntries(headers.entries());
+  } else if (Array.isArray(headers)) {
+      // If headers are in array format, convert them to an object
+      return Object.fromEntries(headers);
+  } else {
+      // Otherwise assume it's already a plain object
+      return headers || {};
+  }
+}
+
+/**
  * A wrapper around fetch that adds default headers.
  * @param fetch {Fetch} - The fetch function to use
  * @param url {string} - The URL to fetch
@@ -118,10 +142,9 @@ const fetchWithHeaders = async (
     'User-Agent': `ollama-js/${version} (${getPlatform()})`,
   } as HeadersInit
 
-  if (!options.headers) {
-    options.headers = {}
-  }
-
+  // Normalizes headers into a plain object format.
+  options.headers = normalizeHeaders(options.headers);
+  
   // Filter out default headers from custom headers
   const customHeaders = Object.fromEntries(
     Object.entries(options.headers).filter(([key]) => !Object.keys(defaultHeaders).some(defaultKey => defaultKey.toLowerCase() === key.toLowerCase()))

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -114,7 +114,11 @@ function getPlatform(): string {
 function normalizeHeaders(headers?: HeadersInit | undefined): Record<string,string> {
   if (headers instanceof Headers) {
       // If headers are an instance of Headers, convert it to an object
-      return Object.fromEntries(headers.entries());
+      const obj: Record<string, string> = {};
+        headers.forEach((value, key) => {
+          obj[key] = value;
+        });
+        return obj;
   } else if (Array.isArray(headers)) {
       // If headers are in array format, convert them to an object
       return Object.fromEntries(headers);

--- a/test/utils.test.ts
+++ b/test/utils.test.ts
@@ -1,0 +1,82 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { get } from '../src/utils'
+
+describe('get Function Header Tests', () => {
+  const mockFetch = vi.fn();
+  const mockResponse = new Response(null, { status: 200 });
+
+  beforeEach(() => {
+    mockFetch.mockReset();
+    mockFetch.mockResolvedValue(mockResponse);
+  });
+
+  const defaultHeaders = {
+    'Content-Type': 'application/json',
+    'Accept': 'application/json',
+    'User-Agent': expect.stringMatching(/ollama-js\/.*/)
+  };
+
+  it('should use default headers when no headers provided', async () => {
+    await get(mockFetch, 'http://example.com');
+    
+    expect(mockFetch).toHaveBeenCalledWith('http://example.com', {
+      headers: expect.objectContaining(defaultHeaders)
+    });
+  });
+
+  it('should handle Headers instance', async () => {
+    const customHeaders = new Headers({
+      'Authorization': 'Bearer token',
+      'X-Custom': 'value'
+    });
+
+    await get(mockFetch, 'http://example.com', { headers: customHeaders });
+
+    expect(mockFetch).toHaveBeenCalledWith('http://example.com', {
+      headers: expect.objectContaining({
+        ...defaultHeaders,
+        'authorization': 'Bearer token',
+        'x-custom': 'value'
+      })
+    });
+  });
+
+  it('should handle plain object headers', async () => {
+    const customHeaders = {
+      'Authorization': 'Bearer token',
+      'X-Custom': 'value'
+    };
+
+    await get(mockFetch, 'http://example.com', { headers: customHeaders });
+
+    expect(mockFetch).toHaveBeenCalledWith('http://example.com', {
+      headers: expect.objectContaining({
+        ...defaultHeaders,
+        'Authorization': 'Bearer token',
+        'X-Custom': 'value'
+      })
+    });
+  });
+
+  it('should not allow custom headers to override default User-Agent', async () => {
+    const customHeaders = {
+      'User-Agent': 'custom-agent'
+    };
+
+    await get(mockFetch, 'http://example.com', { headers: customHeaders });
+
+    expect(mockFetch).toHaveBeenCalledWith('http://example.com', {
+      headers: expect.objectContaining({
+        'User-Agent': expect.stringMatching(/ollama-js\/.*/)
+      })
+    });
+  });
+
+  it('should handle empty headers object', async () => {
+    await get(mockFetch, 'http://example.com', { headers: {} });
+
+    expect(mockFetch).toHaveBeenCalledWith('http://example.com', {
+      headers: expect.objectContaining(defaultHeaders)
+    });
+  });
+});


### PR DESCRIPTION
**Description:**  
This pull request addresses an issue where filtering custom headers using `Object.entries(options.headers)` fails when the headers are not provided as a plain object (for example, when using a `Headers` instance or an array of key-value pairs).  

**Changes Introduced:**  
- Added a new utility function `normalizeHeaders` that converts any valid `HeaderInit` (i.e. a `Headers` instance, an array of key-value pairs, or a plain object) into a plain object.
- Updated the custom header filtering logic to work reliably by first normalizing `options.headers` before filtering out the default headers.
- Included JSDoc documentation for the `normalizeHeaders` function.

**Testing & Impact:**  
- Manually verified that the new implementation correctly processes different header types.
- Ensured that the filtering logic now works uniformly regardless of the header format.
- This improvement ensures better compatibility with the Fetch API and reduces potential errors when using custom headers.