### PR TITLE
Fallback for deprecated `window.navigator.platform`

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -94,9 +94,7 @@ const checkOk = async (response: Response): Promise<void> => {
 function getPlatform(): string {
   if (typeof window !== 'undefined' && window.navigator) {
 const platform = 
-      window.navigator.platform || 
-      window.navigator.userAgentData?.platform ||
-      'unknown';
+      window.navigator.platform || window.navigator.userAgentData?.platform || 'unknown'
     return `${platform.toLowerCase()} Browser/${navigator.userAgent};`
   } else if (typeof process !== 'undefined') {
     return `${process.arch} ${process.platform} Node.js/${process.version}`

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -93,7 +93,11 @@ const checkOk = async (response: Response): Promise<void> => {
  */
 function getPlatform(): string {
   if (typeof window !== 'undefined' && window.navigator) {
-    return `${window.navigator.platform.toLowerCase()} Browser/${navigator.userAgent};`
+    const platform = window.navigator.platform || window.navigator.userAgentData?.platform;
+    if (!platform) {
+      return '';
+    }
+    return `${platform.toLowerCase()} Browser/${navigator.userAgent};`
   } else if (typeof process !== 'undefined') {
     return `${process.arch} ${process.platform} Node.js/${process.version}`
   }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -93,10 +93,10 @@ const checkOk = async (response: Response): Promise<void> => {
  */
 function getPlatform(): string {
   if (typeof window !== 'undefined' && window.navigator) {
-    const platform = window.navigator.platform || window.navigator.userAgentData?.platform;
-    if (!platform) {
-      return '';
-    }
+const platform = 
+      window.navigator.platform || 
+      window.navigator.userAgentData?.platform ||
+      'unknown';
     return `${platform.toLowerCase()} Browser/${navigator.userAgent};`
   } else if (typeof process !== 'undefined') {
     return `${process.arch} ${process.platform} Node.js/${process.version}`


### PR DESCRIPTION
Adding a fallback for the [now deprecated](https://developer.mozilla.org/en-US/docs/Web/API/Navigator/platform) `window.navigator.platform`.

The best alternative seems to be [to use`window.navigator.userAgentData.platform`](https://developer.mozilla.org/en-US/docs/Web/API/Navigator/userAgentData).

Mentioned in https://github.com/ollama/ollama-js/issues/182

I didn't find much contribution guide, so let me know if you need me to give more information.