### PR TITLE
Add missing response properties for `EmbedResponse`

### DIFF
--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -198,6 +198,9 @@ export interface ChatResponse {
 export interface EmbedResponse {
   model: string
   embeddings: number[][]
+  total_duration: number
+  load_duration: number
+  prompt_eval_count: number
 }
 
 export interface EmbeddingsResponse {


### PR DESCRIPTION
After https://github.com/ollama/ollama/pull/5709 (Docs updated in https://github.com/ollama/ollama/pull/6079), requests to the `/embed` endpoint return "metrics" properties including:

* `total_duration`
* `load_duration`
* `prompt_eval_count`

This PR simply adds them to to the `EmbedResponse` type for consistency with Ollama's API.