### PR TITLE
fix(formatHost): support basic auth in host URL

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,6 +1,6 @@
-import { version } from './version.js'
+import { defaultHost, defaultPort } from './constant.js'
 import type { ErrorResponse, Fetch } from './interfaces.js'
-import { defaultPort, defaultHost } from './constant.js'
+import { version } from './version.js'
 
 /**
  * An error class for response errors.
@@ -331,7 +331,17 @@ export const formatHost = (host: string): string => {
     }
   }
 
-  let formattedHost = `${url.protocol}//${url.hostname}:${port}${url.pathname}`
+  // Build basic auth part if present
+  let auth = '';
+  if (url.username) {
+    auth = url.username;
+    if (url.password) {
+      auth += `:${url.password}`;
+    }
+    auth += '@';
+  }
+
+  let formattedHost = `${url.protocol}//${auth}${url.hostname}:${port}${url.pathname}`;
   // remove trailing slashes
   if (formattedHost.endsWith('/')) {
     formattedHost = formattedHost.slice(0, -1)

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -1,6 +1,6 @@
-import { describe, it, expect } from 'vitest'
-import { formatHost } from '../src/utils'
+import { describe, expect, it } from 'vitest'
 import { defaultHost } from '../src/constant'
+import { formatHost } from '../src/utils'
 
 describe('formatHost Function Tests', () => {
   it('should return default URL for empty string', () => {
@@ -61,5 +61,34 @@ describe('formatHost Function Tests', () => {
 
   it('should handle trailing slash with only a port', () => {
     expect(formatHost(':56789/')).toBe('http://127.0.0.1:56789')
+  })
+
+  // Basic Auth Tests
+  it('should preserve username in URL', () => {
+    expect(formatHost('http://user@localhost:1234')).toBe('http://user@localhost:1234')
+  })
+
+  it('should preserve username and password in URL', () => {
+    expect(formatHost('http://user:pass@localhost:5678')).toBe('http://user:pass@localhost:5678')
+  })
+
+  it('should preserve username with default port', () => {
+    expect(formatHost('http://user@localhost')).toBe('http://user@localhost:80')
+  })
+
+  it('should preserve username and password with default port', () => {
+    expect(formatHost('http://user:pass@localhost')).toBe('http://user:pass@localhost:80')
+  })
+
+  it('should preserve basic auth with https', () => {
+    expect(formatHost('https://user:secret@secure.com')).toBe('https://user:secret@secure.com:443')
+  })
+
+  it('should preserve basic auth with domain and custom port', () => {
+    expect(formatHost('http://admin:1234@example.com:8080')).toBe('http://admin:1234@example.com:8080')
+  })
+
+  it('should preserve basic auth and remove trailing slash', () => {
+    expect(formatHost('http://john:doe@site.com:3000/')).toBe('http://john:doe@site.com:3000')
   })
 })


### PR DESCRIPTION
## 🔧 Description
This pull request adds support for Basic Authentication in the formatHost function by including username and password from the input URL into the formatted result.

## 📌 Motivation
Ollama does not provide built-in security or authentication mechanisms. To protect access to the service—especially in shared or production environments—many users set up a reverse proxy like Nginx to enforce Basic Authentication.

For example:

```nginx
http {
    server {
        listen 80;

        auth_basic "Restricted";
        auth_basic_user_file /etc/nginx/.htpasswd;

        location / {
            proxy_pass http://localhost:11434;
        }
    }
}
```

With this configuration, requests to Ollama require valid credentials. In order for clients to successfully communicate through the reverse proxy, they must include credentials in the request URL (e.g., http://user:pass@host:port). This PR ensures that such credentials are preserved in the formatted host string, enabling compatibility with secured proxy setups.

## ✅ Changes
Preserve username and password (if provided) in the output of formatHost.

No impact on behavior for URLs without basic auth.

Maintains removal of trailing slashes and default port logic.

## 🧪 Example

```ts
formatHost('http://admin:1234@localhost:11434/')
// Output: 'http://admin:1234@localhost:11434'
```

## 🧪 Added Tests
Comprehensive test cases have been added for:
- Username only
- Username + password
- Default port cases
- HTTPS with credentials
- Custom ports
- URLs with and without trailing slashes