### PR TITLE
Add `timeout` option

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1536,6 +1536,15 @@
         "undici-types": "~5.26.4"
       }
     },
+    "node_modules/@types/node/node_modules/undici-types": {
+      "version": "5.26.5",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
+      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true
+    },
     "node_modules/@types/resolve": {
       "version": "1.20.2",
       "resolved": "https://registry.npmmirror.com/@types/resolve/-/resolve-1.20.2.tgz",
@@ -4640,13 +4649,6 @@
       "engines": {
         "node": ">=20.18.1"
       }
-    },
-    "node_modules/undici-types": {
-      "version": "5.26.5",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true
     },
     "node_modules/universalify": {
       "version": "2.0.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.0.0",
       "license": "MIT",
       "dependencies": {
+        "undici": "^7.9.0",
         "whatwg-fetch": "^3.6.20"
       },
       "devDependencies": {
@@ -4629,6 +4630,15 @@
       "dev": true,
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/undici": {
+      "version": "7.9.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.9.0.tgz",
+      "integrity": "sha512-e696y354tf5cFZPXsF26Yg+5M63+5H3oE6Vtkh2oqbvsE2Oe7s2nIbcQh5lmG7Lp/eS29vJtTpw9+p6PX0qNSg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
       }
     },
     "node_modules/undici-types": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,12 +9,10 @@
       "version": "0.0.0",
       "license": "MIT",
       "dependencies": {
-        "undici": "^7.9.0",
-        "whatwg-fetch": "^3.6.20"
+        "undici": "^7.9.0"
       },
       "devDependencies": {
         "@swc/core": "^1.3.14",
-        "@types/whatwg-fetch": "^0.0.33",
         "@typescript-eslint/eslint-plugin": "^5.42.1",
         "@typescript-eslint/parser": "^5.42.1",
         "eslint": "^8.29.0",
@@ -1556,26 +1554,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/@types/whatwg-fetch": {
-      "version": "0.0.33",
-      "resolved": "https://registry.npmjs.org/@types/whatwg-fetch/-/whatwg-fetch-0.0.33.tgz",
-      "integrity": "sha512-XSWTlUwpjUyLiDu50HhtpUyhvt7QND1ANfyFfiw/TH63GC1ngZMl2rgxuH5SQKfPjMoKRXv94r7crWnJ3mg5tA==",
-      "deprecated": "fetch types are now provided by '--lib dom'",
-      "dev": true,
-      "dependencies": {
-        "@types/whatwg-streams": "*"
-      }
-    },
-    "node_modules/@types/whatwg-streams": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/@types/whatwg-streams/-/whatwg-streams-3.2.1.tgz",
-      "integrity": "sha512-Syv05sRL25b8cC8tqgXSQgLZZmqGq2GO+NafrtHbjPJccP6gWBXmHvo2Trw3AWXQ4QLIkVuOB7uStCuhzswyiw==",
-      "deprecated": "This is a stub types definition. whatwg-streams provides its own type definitions, so you do not need this installed.",
-      "dev": true,
-      "dependencies": {
-        "whatwg-streams": "*"
-      }
-    },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "5.62.0",
       "dev": true,
@@ -1997,12 +1975,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/bluebird": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-1.0.8.tgz",
-      "integrity": "sha512-e8rlJcByuxPdMiiwU3lGtENflMtUncAblzSlN7rBAZ9ygb75D/rng3Xt5FbZpYqVCzK+sFHVIMht4G6fbfUfbA==",
-      "dev": true
-    },
     "node_modules/boolbase": {
       "version": "1.0.0",
       "resolved": "https://registry.npmmirror.com/boolbase/-/boolbase-1.0.0.tgz",
@@ -2417,12 +2389,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/deep-equal": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-0.1.2.tgz",
-      "integrity": "sha512-rUCt39nKM7s6qUyYgp/reJmtXjgkOS/JbLO24DioMZaBNkD3b7C7cD3zJjSyjclEElNTpetAIRD6fMIbBIbX1Q==",
-      "dev": true
-    },
     "node_modules/deep-is": {
       "version": "0.1.4",
       "dev": true,
@@ -2435,12 +2401,6 @@
       "engines": {
         "node": ">=0.10.0"
       }
-    },
-    "node_modules/defined": {
-      "version": "0.0.0",
-      "resolved": "https://registry.npmjs.org/defined/-/defined-0.0.0.tgz",
-      "integrity": "sha512-zpqiCT8bODLu3QSmLLic8xJnYWBFjOSu/fBCm189oAiTtPq/PSanNACKZDS7kgSyCJY7P+IcODzlIogBK/9RBg==",
-      "dev": true
     },
     "node_modules/defu": {
       "version": "6.1.4",
@@ -3198,15 +3158,6 @@
       },
       "optionalDependencies": {
         "graceful-fs": "^4.1.6"
-      }
-    },
-    "node_modules/jsonify": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.1.tgz",
-      "integrity": "sha512-2/Ki0GcmuqSrgFyelQq9M05y7PS0mEwuIzrf3f1fPqkVDVRvZrPZtVSMHxdgo8Aq0sxAOb/cr2aqqA3LeWHVPg==",
-      "dev": true,
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/keyv": {
@@ -4165,15 +4116,6 @@
         "node": ">=4"
       }
     },
-    "node_modules/resumer": {
-      "version": "0.0.0",
-      "resolved": "https://registry.npmjs.org/resumer/-/resumer-0.0.0.tgz",
-      "integrity": "sha512-Fn9X8rX8yYF4m81rZCK/5VmrmsSbqS/i3rDLl6ZZHAXgC2nTAx3dhwG8q8odP/RmdLa2YrybDJaAMg+X1ajY3w==",
-      "dev": true,
-      "dependencies": {
-        "through": "~2.3.4"
-      }
-    },
     "node_modules/reusify": {
       "version": "1.0.4",
       "dev": true,
@@ -4413,33 +4355,10 @@
         "node": ">=14.0.0"
       }
     },
-    "node_modules/tape": {
-      "version": "2.3.3",
-      "resolved": "https://registry.npmjs.org/tape/-/tape-2.3.3.tgz",
-      "integrity": "sha512-V3tQqlti/JJm577hhDdoCOw1xl4aPcDjTY6PesnFjWDcUYzB6fz39ETXFQuPr9piaoHPfc65sjAehTgbfXOvxQ==",
-      "dev": true,
-      "dependencies": {
-        "deep-equal": "~0.1.0",
-        "defined": "~0.0.0",
-        "inherits": "~2.0.1",
-        "jsonify": "~0.0.0",
-        "resumer": "~0.0.0",
-        "through": "~2.3.4"
-      },
-      "bin": {
-        "tape": "bin/tape"
-      }
-    },
     "node_modules/text-table": {
       "version": "0.2.0",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/through": {
-      "version": "2.3.8",
-      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
-      "integrity": "sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg==",
-      "dev": true
     },
     "node_modules/tinybench": {
       "version": "2.9.0",
@@ -5335,21 +5254,6 @@
         "jsdom": {
           "optional": true
         }
-      }
-    },
-    "node_modules/whatwg-fetch": {
-      "version": "3.6.20",
-      "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-3.6.20.tgz",
-      "integrity": "sha512-EqhiFU6daOA8kpjOWTL0olhVOF3i7OrFzSYiGsEMB8GcXS+RrzauAERX65xMeNWVqxA6HXH2m69Z9LaKKdisfg=="
-    },
-    "node_modules/whatwg-streams": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/whatwg-streams/-/whatwg-streams-0.1.1.tgz",
-      "integrity": "sha512-+UIxdkkbcbhhmcDJIdgVtGTJ7sxV81MY1K++LIWufM8BnIXek3andXURjVs8rV8h2MEFLQbH6YPPZOZATIkZiw==",
-      "dev": true,
-      "dependencies": {
-        "bluebird": "~1.0.0",
-        "tape": "~2.3.2"
       }
     },
     "node_modules/which": {

--- a/package.json
+++ b/package.json
@@ -34,7 +34,6 @@
   "license": "MIT",
   "devDependencies": {
     "@swc/core": "^1.3.14",
-    "@types/whatwg-fetch": "^0.0.33",
     "@typescript-eslint/eslint-plugin": "^5.42.1",
     "@typescript-eslint/parser": "^5.42.1",
     "eslint": "^8.29.0",
@@ -44,7 +43,6 @@
     "vitest": "^2.1.6"
   },
   "dependencies": {
-    "undici": "^7.9.0",
-    "whatwg-fetch": "^3.6.20"
+    "undici": "^7.9.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -38,12 +38,13 @@
     "@typescript-eslint/eslint-plugin": "^5.42.1",
     "@typescript-eslint/parser": "^5.42.1",
     "eslint": "^8.29.0",
-    "vitest": "^2.1.6",
     "prettier": "^3.2.4",
     "typescript": "^5.3.2",
-    "unbuild": "^2.0.0"
+    "unbuild": "^2.0.0",
+    "vitest": "^2.1.6"
   },
   "dependencies": {
+    "undici": "^7.9.0",
     "whatwg-fetch": "^3.6.20"
   }
 }

--- a/src/browser.ts
+++ b/src/browser.ts
@@ -1,6 +1,5 @@
 import * as utils from './utils.js'
 import { AbortableAsyncIterator, parseJSON } from './utils.js'
-import 'whatwg-fetch'
 
 import type {
   ChatRequest,

--- a/src/browser.ts
+++ b/src/browser.ts
@@ -30,6 +30,7 @@ import { defaultHost } from './constant.js'
 export class Ollama {
   protected readonly config: Config
   protected readonly fetch: Fetch
+  protected readonly timeout = 60000 * 10;
   protected readonly ongoingStreamedRequests: AbortableAsyncIterator<object>[] = []
 
   constructor(config?: Partial<Config>) {
@@ -43,6 +44,8 @@ export class Ollama {
     }
 
     this.fetch = config?.fetch ?? fetch
+
+    if (config?.timeout) this.timeout = config.timeout
   }
 
   // Abort any ongoing streamed requests to Ollama
@@ -74,7 +77,8 @@ export class Ollama {
       const abortController = new AbortController()
       const response = await utils.post(this.fetch, host, request, {
         signal: abortController.signal,
-        headers: this.config.headers
+        headers: this.config.headers,
+        timeout: this.timeout,
       })
 
       if (!response.body) {
@@ -96,7 +100,8 @@ export class Ollama {
       return abortableAsyncIterator
     }
     const response = await utils.post(this.fetch, host, request, {
-      headers: this.config.headers
+      headers: this.config.headers,
+      timeout: this.timeout,
     })
     return await response.json()
   }
@@ -237,7 +242,7 @@ async encodeImage(image: Uint8Array | string): Promise<string> {
       this.fetch,
       `${this.config.host}/api/delete`,
       { name: request.model },
-      { headers: this.config.headers }
+      { headers: this.config.headers, timeout: this.timeout }
     )
     return { status: 'success' }
   }
@@ -250,7 +255,8 @@ async encodeImage(image: Uint8Array | string): Promise<string> {
    */
   async copy(request: CopyRequest): Promise<StatusResponse> {
     await utils.post(this.fetch, `${this.config.host}/api/copy`, { ...request }, {
-      headers: this.config.headers
+      headers: this.config.headers,
+      timeout: this.timeout,
     })
     return { status: 'success' }
   }
@@ -262,7 +268,8 @@ async encodeImage(image: Uint8Array | string): Promise<string> {
    */
   async list(): Promise<ListResponse> {
     const response = await utils.get(this.fetch, `${this.config.host}/api/tags`, {
-      headers: this.config.headers
+      headers: this.config.headers,
+      timeout: this.timeout,
     })
     return (await response.json()) as ListResponse
   }
@@ -276,7 +283,8 @@ async encodeImage(image: Uint8Array | string): Promise<string> {
     const response = await utils.post(this.fetch, `${this.config.host}/api/show`, {
       ...request,
     }, {
-      headers: this.config.headers
+      headers: this.config.headers,
+      timeout: this.timeout,
     })
     return (await response.json()) as ShowResponse
   }
@@ -290,7 +298,8 @@ async encodeImage(image: Uint8Array | string): Promise<string> {
       const response = await utils.post(this.fetch, `${this.config.host}/api/embed`, {
         ...request,
       }, {
-        headers: this.config.headers
+        headers: this.config.headers,
+        timeout: this.timeout,
       })
       return (await response.json()) as EmbedResponse
     }
@@ -304,7 +313,8 @@ async encodeImage(image: Uint8Array | string): Promise<string> {
     const response = await utils.post(this.fetch, `${this.config.host}/api/embeddings`, {
       ...request,
     }, {
-      headers: this.config.headers
+      headers: this.config.headers,
+      timeout: this.timeout,
     })
     return (await response.json()) as EmbeddingsResponse
   }
@@ -316,7 +326,8 @@ async encodeImage(image: Uint8Array | string): Promise<string> {
    */
   async ps(): Promise<ListResponse> {
     const response = await utils.get(this.fetch, `${this.config.host}/api/ps`, {
-      headers: this.config.headers
+      headers: this.config.headers,
+      timeout: this.timeout,
     })
     return (await response.json()) as ListResponse
   }

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -4,7 +4,8 @@ export interface Config {
   host: string
   fetch?: Fetch
   proxy?: boolean
-  headers?: HeadersInit
+  headers?: HeadersInit,
+  timeout?: number
 }
 
 // request types

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -147,7 +147,7 @@ function normalizeHeaders(headers?: HeadersInit | undefined): Record<string,stri
 const fetchWithHeaders = async (
   fetch: Fetch,
   url: string,
-  options: RequestInit = {},
+  options: RequestInit & { timeout?: number } = {},
 ): Promise<Response> => {
   const defaultHeaders = {
     'Content-Type': 'application/json',

--- a/test/utils.test.ts
+++ b/test/utils.test.ts
@@ -1,6 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { get } from '../src/utils'
-import { Agent } from 'undici';
 
 describe('get Function Header Tests', () => {
   const mockFetch = vi.fn();
@@ -21,8 +20,7 @@ describe('get Function Header Tests', () => {
     await get(mockFetch, 'http://example.com');
     
     expect(mockFetch).toHaveBeenCalledWith('http://example.com', {
-      headers: expect.objectContaining(defaultHeaders),
-      dispatcher: expect.any(new Agent())
+      headers: expect.objectContaining(defaultHeaders)
     });
   });
 

--- a/test/utils.test.ts
+++ b/test/utils.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { get } from '../src/utils'
+import { Agent } from 'undici';
 
 describe('get Function Header Tests', () => {
   const mockFetch = vi.fn();
@@ -20,7 +21,8 @@ describe('get Function Header Tests', () => {
     await get(mockFetch, 'http://example.com');
     
     expect(mockFetch).toHaveBeenCalledWith('http://example.com', {
-      headers: expect.objectContaining(defaultHeaders)
+      headers: expect.objectContaining(defaultHeaders),
+      dispatcher: expect.any(Agent),
     });
   });
 
@@ -37,7 +39,8 @@ describe('get Function Header Tests', () => {
         ...defaultHeaders,
         'authorization': 'Bearer token',
         'x-custom': 'value'
-      })
+      }),
+      dispatcher: expect.any(Agent),
     });
   });
 
@@ -54,7 +57,8 @@ describe('get Function Header Tests', () => {
         ...defaultHeaders,
         'Authorization': 'Bearer token',
         'X-Custom': 'value'
-      })
+      }),
+      dispatcher: expect.any(Agent),
     });
   });
 
@@ -68,7 +72,8 @@ describe('get Function Header Tests', () => {
     expect(mockFetch).toHaveBeenCalledWith('http://example.com', {
       headers: expect.objectContaining({
         'User-Agent': expect.stringMatching(/ollama-js\/.*/)
-      })
+      }),
+      dispatcher: expect.any(Agent),
     });
   });
 
@@ -76,7 +81,8 @@ describe('get Function Header Tests', () => {
     await get(mockFetch, 'http://example.com', { headers: {} });
 
     expect(mockFetch).toHaveBeenCalledWith('http://example.com', {
-      headers: expect.objectContaining(defaultHeaders)
+      headers: expect.objectContaining(defaultHeaders),
+      dispatcher: expect.any(Agent),
     });
   });
 });

--- a/test/utils.test.ts
+++ b/test/utils.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { get } from '../src/utils'
+import { Agent } from 'undici';
 
 describe('get Function Header Tests', () => {
   const mockFetch = vi.fn();
@@ -20,7 +21,8 @@ describe('get Function Header Tests', () => {
     await get(mockFetch, 'http://example.com');
     
     expect(mockFetch).toHaveBeenCalledWith('http://example.com', {
-      headers: expect.objectContaining(defaultHeaders)
+      headers: expect.objectContaining(defaultHeaders),
+      dispatcher: expect.any(new Agent())
     });
   });
 


### PR DESCRIPTION
Resolves timeout issues with older machines (especially those running on CPU) caused by a [300 second](https://github.com/nodejs/undici/issues/1373) timeout constant.

* Removes `whatwg-fetch` import in favor of [`undici`](https://undici.nodejs.org)
* Adds a `timeout` prop to the request options, passing those to a new `Agent`

Resolves #72 

# Tests

On a crumby computer (or resource limited container) run:

```javascript
require('ollama')
  .default.chat({
    model: 'gemma3:27b',
    messages: [{ role: 'user', content: 'Why is the sky blue?' }],
  })
  .then((i) => console.log(i));
```

Resulting in:

```json
{
  "model": "gemma3:27b",
  "created_at": "2025-05-19T18:23:45.15035873Z",
  "message": {
    "role": "assistant",
    "content": "The sky is blue because of a phenomenon called **Rayleigh scattering**. Here's a breakdown..."
  },
  "done_reason": "stop",
  "done": true,
  "total_duration": 470459553167,
  "load_duration": 6352338645,
  "prompt_eval_count": 15,
  "prompt_eval_duration": 4274237804,
  "eval_count": 500,
  "eval_duration": 459831723963
}
```

7 minutes, nice!